### PR TITLE
Lowercase pack values

### DIFF
--- a/Bethini.json
+++ b/Bethini.json
@@ -192,7 +192,7 @@
     "Basic": {
       "Display": {
         "Pack": {
-          "Fill": "None",
+          "Fill": "none",
           "Expand": 0
         },
         "NumberOfVerticallyStackedSettings": "6",
@@ -411,7 +411,7 @@
       },
       "Presets": {
         "Pack": {
-          "Fill": "None",
+          "Fill": "none",
           "Expand": 0
         },
         "NumberOfVerticallyStackedSettings": "2",
@@ -477,7 +477,7 @@
       },
       "NoLabelFrame": {
         "Pack": {
-          "Fill": "X",
+          "Fill": "x",
           "Expand": 0
         },
         "NumberOfVerticallyStackedSettings": "2",
@@ -563,7 +563,7 @@
     "General": {
       "NoLabelFrame": {
         "Pack": {
-          "Fill": "X",
+          "Fill": "x",
           "Expand": 0
         },
         "NumberOfVerticallyStackedSettings": "1",
@@ -640,8 +640,8 @@
       },
       "Saved Games": {
         "Pack": {
-          "Side": "Left",
-          "Fill": "None",
+          "Side": "left",
+          "Fill": "none",
           "Expand": 0
         },
         "NumberOfVerticallyStackedSettings": "7",
@@ -775,8 +775,8 @@
       },
       "Gameplay": {
         "Pack": {
-          "Side": "Left",
-          "Fill": "X",
+          "Side": "left",
+          "Fill": "x",
           "Expand": 0
         },
         "NumberOfVerticallyStackedSettings": "6",
@@ -847,7 +847,7 @@
       },
       "Screenshots": {
         "Pack": {
-          "Fill": "None",
+          "Fill": "none",
           "Expand": 0
         },
         "NumberOfVerticallyStackedSettings": "5",
@@ -910,8 +910,8 @@
       },
       "Papyrus": {
         "Pack": {
-          "Side": "Left",
-          "Fill": "None",
+          "Side": "left",
+          "Fill": "none",
           "Expand": 0
         },
         "NumberOfVerticallyStackedSettings": "3",
@@ -1082,8 +1082,8 @@
       },
       "Colors": {
         "Pack": {
-          "Side": "Left",
-          "Fill": "Y"
+          "Side": "left",
+          "Fill": "y"
         },
         "NumberOfVerticallyStackedSettings": "10",
         "Settings": {
@@ -1181,8 +1181,8 @@
       },
       "Pip-Boy": {
         "Pack": {
-          "Side": "Left",
-          "Fill": "Y"
+          "Side": "left",
+          "Fill": "y"
         },
         "NumberOfVerticallyStackedSettings": "12",
         "Settings": {
@@ -1267,7 +1267,7 @@
       },
       "Controller Settings": {
         "Pack": {
-          "Fill": "Y"
+          "Fill": "y"
         },
         "NumberOfVerticallyStackedSettings": "5",
         "Settings": {
@@ -1323,8 +1323,8 @@
       },
       "Mouse Settings": {
         "Pack": {
-          "Side": "Left",
-          "Fill": "Y"
+          "Side": "left",
+          "Fill": "y"
         },
         "NumberOfVerticallyStackedSettings": "5",
         "Settings": {
@@ -1386,8 +1386,8 @@
       },
       "Console": {
         "Pack": {
-          "Side": "Left",
-          "Fill": "Y"
+          "Side": "left",
+          "Fill": "y"
         },
         "NumberOfVerticallyStackedSettings": "5",
         "Settings": {
@@ -1441,7 +1441,7 @@
     "Visuals": {
       "Effects": {
         "Pack": {
-          "Fill": "None"
+          "Fill": "none"
         },
         "NumberOfVerticallyStackedSettings": "2",
         "Settings": {
@@ -1538,7 +1538,7 @@
       },
       "Decals": {
         "Pack": {
-          "Side": "Left"
+          "Side": "left"
         },
         "NumberOfVerticallyStackedSettings": "8",
         "Settings": {
@@ -1774,7 +1774,7 @@
       },
       "Shadows": {
         "Pack": {
-          "Side": "Left"
+          "Side": "left"
         },
         "NumberOfVerticallyStackedSettings": "5",
         "Settings": {
@@ -2195,8 +2195,8 @@
       },
       "Distant Details": {
         "Pack": {
-          "Side": "Left",
-          "Fill": "Y"
+          "Side": "left",
+          "Fill": "y"
         },
         "NumberOfVerticallyStackedSettings": "5",
         "Settings": {


### PR DESCRIPTION
Makes Pack values lowercase to be consistent with tkinter constants like `tk.LEFT` so they don't need special handling.
Needed for DoubleYouC/Bethini-Pie-Performance-INI-Editor#25